### PR TITLE
Add model metadata

### DIFF
--- a/liftwing/__init__.py
+++ b/liftwing/__init__.py
@@ -1,1 +1,5 @@
-from .models.revertrisk import RevertRiskAPIModel
+from .models.revertrisk import RevertRiskAPIModel, revertrisk_metadata
+
+__metadata__ = [
+    revertrisk_metadata
+]

--- a/liftwing/models/liftwing_model.py
+++ b/liftwing/models/liftwing_model.py
@@ -30,3 +30,20 @@ class LiftwingModel(ABC):
         response = requests.post(self.base_url, json=payload, headers=headers)
 
         return response.json()
+
+
+class ModelMetadata(BaseModel):
+    name: str
+    classname: str
+    api_documentation_url: str
+    wmf_model_card_url: str
+
+    def __repr__(self):
+        return (
+            f"(\n"
+            f"    name={self.name},\n"
+            f"    classname={self.classname},\n"
+            f"    api_documentation_url={self.api_documentation_url},\n"
+            f"    wmf_model_card_url={self.wmf_model_card_url}\n"
+            f")"
+        )

--- a/liftwing/models/revertrisk.py
+++ b/liftwing/models/revertrisk.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 
-from .liftwing_model import LiftwingModel
+from .liftwing_model import LiftwingModel, ModelMetadata
 
 
 class RevertRiskPayload(BaseModel):
@@ -13,6 +13,13 @@ class RevertRiskPayload(BaseModel):
                         description="The revision id for the wiki identified by the lang parameter.",
                         gt=0)
 
+
+revertrisk_metadata = ModelMetadata(
+    name="Language-agnostic revert risk",
+    classname="RevertRiskAPIModel",
+    api_documentation_url="https://api.wikimedia.org/wiki/Lift_Wing_API/Reference/Get_reverted_risk_language_agnostic_prediction",
+    wmf_model_card_url="https://meta.wikimedia.org/wiki/Machine_learning_models/Proposed/Language-agnostic_revert_risk"
+)
 
 class RevertRiskAPIModel(LiftwingModel):
     def __init__(self, base_url="https://api.wikimedia.org/service/lw/inference/v1/models/revertrisk-language-agnostic:predict"):


### PR DESCRIPTION
Add the option of listing available models in the package.
After installing the package the user can run `python -m liftwing` and get a list of available models along with the API Documentation link and the model card. 
When adding a new model the developer needs to add the relevant metadata for the model (create an instance of a pydantic ModelMetadata class) and add that to the __init__.py of liftwing. Then __main__.py picks all __metadata__ and prints them.

Alternatively this could be done using a `--list` argument but I thought that it wasn't needed for now to make things simpler.
If however we plan to add more functionality to this in the future it would be better to do it from now. Let me know what you think.

```
 python -m liftwing
(
    name=Language-agnostic revert risk,
    classname=RevertRiskAPIModel,
    api_documentation_url=https://api.wikimedia.org/wiki/Lift_Wing_API/Reference/Get_reverted_risk_language_agnostic_prediction,
    wmf_model_card_url=https://meta.wikimedia.org/wiki/Machine_learning_models/Proposed/Language-agnostic_revert_risk
)

```