### PR TITLE
add readability with validation

### DIFF
--- a/liftwing/__init__.py
+++ b/liftwing/__init__.py
@@ -1,4 +1,6 @@
+from .models.readability import ReadabilityModel, readability_metadata
 from .models.revertrisk import RevertRiskAPIModel, revertrisk_metadata
+
 from .models.revscoring import (
     RevscoringModel,
     damaging_metadata,
@@ -11,6 +13,7 @@ from .models.revscoring import (
 )
 
 __metadata__ = [
+    readability_metadata,
     revertrisk_metadata,
     damaging_metadata,
     goodfaith_metadata,
@@ -20,4 +23,4 @@ __metadata__ = [
     draftquality_metadata,
     drafttopic_metadata,
 ]
-__all__ = [RevertRiskAPIModel, RevscoringModel]
+__all__ = [ReadabilityModel, RevertRiskAPIModel, RevscoringModel]

--- a/liftwing/models/readability.py
+++ b/liftwing/models/readability.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel, Field
+
+from .liftwing_model import LiftwingModel, ModelMetadata
+
+
+class ReadabilityPayload(BaseModel):
+    lang: str = Field(
+        ...,
+        title="Language code of the wiki",
+        description="A string representing the language code related to the target "
+        'wiki. Example: "en" for English Wikipedia.',
+    )
+    rev_id: int = Field(
+        ...,
+        title="Revision ID of the edit",
+        description="The revision id for the wiki identified by the lang parameter.",
+        gt=0,
+    )
+
+
+readability_metadata = ModelMetadata(
+    name="Multilingual readability",
+    classname="ReadabilityModel",
+    api_documentation_url="https://api.wikimedia.org/wiki/Lift_Wing_API/Reference/Get_readability_prediction",
+    wmf_model_card_url="https://meta.wikimedia.org/wiki/Machine_learning_models/Proposed/Multilingual_readability_model_card",
+)
+
+
+class ReadabilityModel(LiftwingModel):
+    def __init__(
+        self,
+        base_url="https://api.wikimedia.org/service/lw/inference/v1/models/readability:predict",
+    ):
+        super().__init__(base_url, ReadabilityPayload)


### PR DESCRIPTION
This is an example Pull Request of how to add a model with validation and metadata

# get prediction
```
from liftwing import ReadabilityModel
client = ReadabilityModel()

print(client.request(payload={"lang": "en", "rev_id": 123456}))
```

# model is also listed in available models
```
python -m liftwing
(
    name=Language-agnostic revert risk,
    classname=RevertRiskAPIModel,
    api_documentation_url=https://api.wikimedia.org/wiki/Lift_Wing_API/Reference/Get_reverted_risk_language_agnostic_prediction,
    wmf_model_card_url=https://meta.wikimedia.org/wiki/Machine_learning_models/Proposed/Language-agnostic_revert_risk
)
(
    name=Multilingual readability,
    classname=ReadabilityModel,
    api_documentation_url=https://api.wikimedia.org/wiki/Lift_Wing_API/Reference/Get_readability_prediction,
    wmf_model_card_url=https://meta.wikimedia.org/wiki/Machine_learning_models/Proposed/Multilingual_readability_model_card
)

```